### PR TITLE
fix: install: use correct binary name to download binaries artifacts for linux

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,12 +21,12 @@ error_exit() {
 platform() {
   local -r os=$(
     case "$(uname | tr '[:upper:]' '[:lower:]')" in
-      darwin) echo "osx" ;;
-      *) echo "linux" ;;
+      darwin) echo "osx-amd64" ;;
+      *) echo "linux64" ;;
     esac
   )
 
-  echo "${os}-amd64"
+  echo "${os}"
 }
 
 install() {


### PR DESCRIPTION
Current release of asdf-jq can't be used on linux, as the artifact name is incorrect.