### PR TITLE
feat: remove 'jq-' prefix from versions list to allow 'latest' keyword usage in asdf

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -34,7 +34,7 @@ install() {
   local -r install_version="$2"
   local -r install_path="$3"
   local -r install_path_bin="${install_path}/bin"
-  local -r download_url="${DOWNLOAD_BASE_URL}/${install_version}/${BINARY_NAME}-$(platform)"
+  local -r download_url="${DOWNLOAD_BASE_URL}/jq-${install_version}/${BINARY_NAME}-$(platform)"
   local -r download_path="${TMP_DOWNLOAD_DIR}/${BINARY_NAME}"
 
   [ "$install_type" != "version" ] && error_exit "Error: source installs are not supported"

--- a/bin/list-all
+++ b/bin/list-all
@@ -20,7 +20,7 @@ sort_versions() {
 list_versions() {
   cmd="curl -fsS --url $RELEASES_URL"
   [ -n "$GITHUB_API_TOKEN" ] && cmd+=" -H 'Authorization: token $GITHUB_API_TOKEN'"
-  echo "$(eval $cmd | grep -oE "tag_name\": *\".*\"," | sed 's/tag_name\": *\"//;s/\",//')"
+  echo "$(eval $cmd | grep -oE "tag_name\": *\".*\"," | sed 's/tag_name\": *\"//;s/\",//; s/jq-//')"
 }
 
 #


### PR DESCRIPTION
As versions list is returned with the `jq-` prefix, asdf can't figure out which version is the latest one, therefore, the `latest` keyword can't be used correctly.
This allow a correct version listing, while using the `latest` keyword