### PR TITLE
Interprete command substitution correctly in Bash

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -21,8 +21,8 @@ error_exit() {
 platform() {
   local -r os=$(
     case "$(uname | tr '[:upper:]' '[:lower:]')" in
-      darwin) echo "osx" ;;
-      *) echo "linux" ;;
+      (darwin) echo "osx" ;;
+      (*) echo "linux" ;;
     esac
   )
 


### PR DESCRIPTION
When running install command in MacOS Catalina (Bash version 3.2.57),
the install command fails with the error:

    .asdf/plugins/jq/bin/install: line 24: syntax error near unexpected token `;;'

This is because in the platform function the command substitution is
misinterpreted due to the closing parentheses of the case patterns.

Prefixing the case patterns with opening parenthenses ensures that the
command substitution is interpreted correctly.