### PR TITLE
Follow redirects when listing versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -18,7 +18,7 @@ sort_versions() {
 }
 
 list_versions() {
-  cmd="curl -fsS --url $RELEASES_URL"
+  cmd="curl -fsSL --url $RELEASES_URL"
   [ -n "$GITHUB_API_TOKEN" ] && cmd+=" -H 'Authorization: token $GITHUB_API_TOKEN'"
   echo "$(eval $cmd | grep -oE "tag_name\": *\".*\"," | sed 's/tag_name\": *\"//;s/\",//')"
 }


### PR DESCRIPTION
Looks like the github API changed and will redirect - instruct curl to follow redirects.

```
curl -fsS --url $RELEASES_URL
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/5101141/releases",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```